### PR TITLE
Do not quote strings TOML-style in the metadata

### DIFF
--- a/src/models/metadata_model.rs
+++ b/src/models/metadata_model.rs
@@ -55,6 +55,7 @@ impl MetadataModel {
         for (key, value) in table {
             let value_string = match value {
                 Value::Float(val) => format!("{:.2e}", val),
+                Value::String(val) => val.clone(),
                 other => other.to_string(),
             };
             self.inner


### PR DESCRIPTION
When a value is a string, do not display:

"value"

but:

value