### PR TITLE
Show relative indices of subwords

### DIFF
--- a/src/ui/subwords_widget.glade
+++ b/src/ui/subwords_widget.glade
@@ -101,7 +101,7 @@
             <child>
               <object class="GtkTreeViewColumn">
                 <property name="resizable">True</property>
-                <property name="title" translatable="yes">Index</property>
+                <property name="title" translatable="yes">Subword Index</property>
                 <property name="sort_indicator">True</property>
                 <property name="sort_column_id">1</property>
                 <child>


### PR DESCRIPTION
The absolute storage indices of subwords are large and difficult to
interpret without knowing and subtracting the word vocab length. So,
show the subword indices as a relative offset to the first subword
index.