### PR TITLE
Fix: display angular similarity in queries

### DIFF
--- a/src/models/similarity_model.rs
+++ b/src/models/similarity_model.rs
@@ -57,7 +57,7 @@ impl SimilarityModel {
                 &[
                     &similar_word.word,
                     &similar_word.similarity.into_inner(),
-                    &format!("{:.2}", similar_word.similarity),
+                    &format!("{:.2}", angular_similarity),
                     &((angular_similarity * 100f32) as i32),
                 ],
             );
@@ -93,7 +93,7 @@ impl SimilarityModel {
                 &[
                     &similar_word.word,
                     &similar_word.similarity.into_inner(),
-                    &format!("{:.2}", similar_word.similarity),
+                    &format!("{:.2}", angular_similarity),
                     &((angular_similarity * 100f32) as i32),
                 ],
             );

--- a/src/ui/inspector_window.rs
+++ b/src/ui/inspector_window.rs
@@ -65,9 +65,9 @@ impl InspectorWindow {
         let inspector_window = Rc::new(InspectorWindow {
             inner: window.clone(),
             widgets: vec![
-                similarity_widget.clone(),
-                analogy_widget.clone(),
-                subwords_widget.clone(),
+                similarity_widget,
+                analogy_widget,
+                subwords_widget,
                 metadata_dialog.clone(),
             ],
         });


### PR DESCRIPTION
The progress bars in the 'Similarity' column were based on angular
similarity, but the string representations displayed cosine
similarities.